### PR TITLE
Protect against race condition

### DIFF
--- a/src/com/makina/security/openfips201/PIVSecurityProvider.java
+++ b/src/com/makina/security/openfips201/PIVSecurityProvider.java
@@ -437,18 +437,6 @@ final class PIVSecurityProvider {
       return; // Keep compiler happy
     }
 
-    // Update the PIN
-    pin.update(buffer, offset, length);
-
-    // Update the PIN History if enabled
-    if (historyCount > 0) {
-      // Move/Roll to the next position we will write to
-      byte next = persistentState[STATE_HISTORY_NEXT];
-      pinHistory[next].update(buffer, offset, length);
-      next = (byte) ((byte) (next + (byte) 1) % historyCount);
-      persistentState[STATE_HISTORY_NEXT] = next;
-    }
-
     // VotingWorks modification: Clear all PIN-gated keys
     PIVObject key = firstKey;
     while (key != null) {
@@ -469,7 +457,19 @@ final class PIVSecurityProvider {
       }
       key = key.nextObject;
     }
-  }
+
+    // Update the PIN
+    pin.update(buffer, offset, length);
+
+    // Update the PIN History if enabled
+    if (historyCount > 0) {
+      // Move/Roll to the next position we will write to
+      byte next = persistentState[STATE_HISTORY_NEXT];
+      pinHistory[next].update(buffer, offset, length);
+      next = (byte) ((byte) (next + (byte) 1) % historyCount);
+      persistentState[STATE_HISTORY_NEXT] = next;
+    }
+}
 
   /**
    * Performs a comprehensive erase of the target buffer


### PR DESCRIPTION
If a failure occurs during PIN reset, we could end up with a PIN reset but certs not cleared. We don't want that. So we clear the certs first.

I imagine there are more things I need to do here, like rebuild the applet etc, but getting the ball rolling.